### PR TITLE
Fix for multiple accessories

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ function PanasonicAC(log, config) {
 	this.uToken = null;
 
 	this.deviceNumber = config["devicenumber"] || 1;
+	this.groupNumber = config["groupnumber"] || 1;
 	this.version = "1.7.0";
 
 	// Start running the refresh process (login and set timer)
@@ -156,7 +157,7 @@ PanasonicAC.prototype = {
 
 						try {
 							this.log("Login complete");
-							this.device = body['groupList'][this.deviceNumber-1]['deviceIdList'][this.deviceNumber-1]['deviceGuid'];
+							this.device = body['groupList'][this.groupnumber-1]['deviceIdList'][this.deviceNumber-1]['deviceGuid'];
 							this.hcService.getCharacteristic(Characteristic.StatusFault).updateValue(Characteristic.StatusFault.NO_FAULT);
 						}
 						catch(err) {


### PR DESCRIPTION
This modification will fix the issue with multiple accessories with different device numbers(but in the same group). Important to not, that if you plan to use multiple accessories, create separate user accounts for each, because the auth token will be overwritten otherwise, so only the last accessory will work. 